### PR TITLE
the empty instrument to be considered

### DIFF
--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -41,7 +41,8 @@ def test_empty_request(dispatcher_live_fixture):
     assert c.status_code == 400
 
      # parameterize this
-    assert jdata['installed_instruments'] == ['isgri', 'jemx', 'osa_fake'] or \
+    assert jdata['installed_instruments'] == ['empty', 'isgri', 'jemx', 'osa_fake'] or \
+           jdata['installed_instruments'] == ['empty'] or \
            jdata['installed_instruments'] == []
 
     assert jdata['debug_mode'] == "yes"


### PR DESCRIPTION
When considering the installed instruments, now also the __empty__ one needs to be considered. I added this with [b8f912b](https://github.com/oda-hub/dispatcher-app/commit/b8f912b44824ea657c5b716778b8a040ed8b08b3).

The test [](https://github.com/oda-hub/dispatcher-app/blob/093c061562ee67ba08a06afef6351763820c1198/tests/test_server_basic.py#L156) uses actually that one.

Now the test [test_empty_request](https://github.com/oda-hub/dispatcher-app/blob/093c061562ee67ba08a06afef6351763820c1198/tests/test_server_basic.py#L29) considers this option.

I am ok with moving this type of instrument somewhere else to be more consistent though.