### PR TITLE
Prevented aliasing different users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ jdata.json
 /tests/query_catalog.fits
 /tests/data/dummy_prods/isgri_query_mosaic.fits
 /tests/data/dummy_prods/query_catalog.fits
+/tests/local_smtp_log

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -578,10 +578,13 @@ class InstrumentQueryBackEnd:
         job_monitor_status_json_file_aliased = f'scratch_sid_{session_id}_jid_{job_id}_aliased/query_output.json'
         request_url = ""
         file = None
-        if os.path.exists(job_monitor_status_json_file):
-            file = open(job_monitor_status_json_file)
-        elif os.path.exists(job_monitor_status_json_file_aliased):
-            file = open(job_monitor_status_json_file_aliased)
+        if self.scratch_dir:
+            file = open(self.scratch_dir + '/query_output.json')
+        else:
+            if os.path.exists(job_monitor_status_json_file_aliased):
+                file = open(job_monitor_status_json_file_aliased)
+            elif os.path.exists(job_monitor_status_json_file):
+                file = open(job_monitor_status_json_file)
         if file:
             jdata = json.load(file)
             if 'prod_dictionary' in jdata and 'analysis_parameters' in jdata['prod_dictionary']:

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -135,6 +135,12 @@ class InstrumentQueryBackEnd:
             if 'token' in self.par_dic.keys() and self.par_dic['token'] != "":
                 self.token = self.par_dic['token']
                 self.public = False
+                # token validation and decoding can be done here, to check if the token is expired
+                try:
+                    if self.validate_query_from_token():
+                        pass
+                except jwt.exceptions.ExpiredSignatureError as e:
+                    raise RequestNotAuthorized("token expired")
 
             if instrument_name is None:
                 if 'instrument' in self.par_dic:
@@ -234,7 +240,7 @@ class InstrumentQueryBackEnd:
         return format_hash(json.dumps(o))
 
     # not job_id??
-    def generate_job_id(self, kw_black_list=['session_id', 'job_id']):
+    def generate_job_id(self, kw_black_list=['session_id', 'job_id', 'token']):
         self.logger.info("\033[31m---> GENERATING JOB ID <---\033[0m")
         self.logger.info(
             "\033[31m---> new job id for %s <---\033[0m", self.par_dic)
@@ -252,6 +258,9 @@ class InstrumentQueryBackEnd:
             k: v for k, v in self.par_dic.items()
             if k not in kw_black_list
         })
+        if not self.public:
+            # token has not been considered, but the user id will be (if availaable)
+            _dict['sub'] = tokenHelper.get_token_user_email_address(self.decoded_token)
 
         self.job_id = u'%s' % (self.make_hash(_dict))
 
@@ -565,9 +574,15 @@ class InstrumentQueryBackEnd:
 
     def generate_request_url_call_back(self, products_url, session_id, job_id) -> str:
         job_monitor_status_json_file = f'scratch_sid_{session_id}_jid_{job_id}/query_output.json'
+        # to be handled now, with the job_id generated taking into account only the user_id
+        job_monitor_status_json_file_aliased = f'scratch_sid_{session_id}_jid_{job_id}_aliased/query_output.json'
         request_url = ""
+        file = None
         if os.path.exists(job_monitor_status_json_file):
             file = open(job_monitor_status_json_file)
+        elif os.path.exists(job_monitor_status_json_file_aliased):
+            file = open(job_monitor_status_json_file_aliased)
+        if file:
             jdata = json.load(file)
             if 'prod_dictionary' in jdata and 'analysis_parameters' in jdata['prod_dictionary']:
                 request_par_dict = jdata['prod_dictionary']['analysis_parameters']
@@ -1039,10 +1054,10 @@ class InstrumentQueryBackEnd:
         except KeyError as e:
             raise MissingRequestParameter(repr(e))
 
-        resp = self.validate_token_request_param()
-        if resp is not None:
-            self.logger.warning("query dismissed by token validation")
-            return resp
+        # resp = self.validate_token_request_param()
+        # if resp is not None:
+        #     self.logger.warning("query dismissed by token validation")
+        #     return resp
 
         if self.par_dic.pop('instrumet', None) is not None:
             self.logger.warning("someone is sending instrume(N!)ts?")

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -594,12 +594,11 @@ class InstrumentQueryBackEnd:
         duration_query = -1
         if self.time_request:
             duration_query = time_.time() - self.time_request
-        if self.token:
-            resp = self.validate_token_request_param()
-            if resp is not None:
-                self.logger.warning("query dismissed by token validation")
-                return resp
-
+        if not self.public:
+            # resp = self.validate_token_request_param()
+            # if resp is not None:
+            #     self.logger.warning("query dismissed by token validation")
+            #     return resp
             timeout_threshold_mail = tokenHelper.get_token_user_timeout_threshold_mail(self.decoded_token)
             if timeout_threshold_mail is None:
                 # set it to the a default value, from the configuration

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -142,14 +142,12 @@ def test_invalid_token(dispatcher_live_fixture, ):
 
     jdata = ask(server,
                 params,
-                expected_query_status=["failed"],
                 max_time_s=50,
+                expected_query_status=None,
+                expected_status_code=403
                 )
 
-    assert jdata["exit_status"]["debug_message"] == ""
-    assert jdata["exit_status"]["error_message"] == ""
-    assert jdata["exit_status"]["message"] == "token expired"
-
+    assert jdata['error_message'] == 'token expired'
     logger.info("Json output content")
     logger.info(json.dumps(jdata, indent=4))
 

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -146,15 +146,9 @@ def test_same_request_different_users(dispatcher_live_fixture):
 
     assert job_id_1 != job_id_2
 
-    job_monitor_json_fn_1 = f'scratch_sid_{session_id_1}_jid_{job_id_1}'
-    job_monitor_json_fn_2 = f'scratch_sid_{session_id_2}_jid_{job_id_2}'
-
-    assert os.path.exists(job_monitor_json_fn_1) and os.path.exists(job_monitor_json_fn_2)
-
-    dir_list_1 = glob.glob('*_jid_%s_aliased' % job_id_1)
-    assert len(dir_list_1) == 0
-    dir_list_2 = glob.glob('*_jid_%s_aliased' % job_id_2)
-    assert len(dir_list_2) == 0
+    dir_list_1 = glob.glob('*_jid_%s*' % job_id_1)
+    dir_list_2 = glob.glob('*_jid_%s*' % job_id_2)
+    assert len(dir_list_1) == len(dir_list_2)
 
 def test_valid_token(dispatcher_live_fixture):
     server = dispatcher_live_fixture


### PR DESCRIPTION
Will generate the job_idtaking into account also the user_id, so that two users generating the very same request yield differen scratch folders.

Wokring on some tests now.