### PR TITLE
'None' (string, not python None) appears in callback for public requests, and is causing failures

### DIFF
--- a/cdci_data_analysis/analysis/job_manager.py
+++ b/cdci_data_analysis/analysis/job_manager.py
@@ -213,6 +213,9 @@ class Job(object):
                 "token", "time_request"
             ]})
 
+        # properly setting the original time of the request
+        url = url.replace('time_request', 'time_original_request')
+
         url += '&progressing'
 
         logger.debug("callback url: %s", url)

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -274,12 +274,15 @@ def dataserver_call_back():
     #log = logging.getLogger('werkzeug')
     #log.disabled = True
     #app.logger.disabled = True
-    print('===========================> dataserver_call_back')
+    logger.info('\033[32m===========================> dataserver_call_back\033[0m')
+
+    logger.info('\033[33m raw request values: %s \033[0m', dict(request.values))
+
     query = InstrumentQueryBackEnd(
     # TODO get rid of the mock instrument
         app, instrument_name='mock', data_server_call_back=True)
     query.run_call_back()
-    print('===========================>\n\n\n')
+    logger.info('\033[32m===========================> dataserver_call_back DONE\033[0m')    
     return jsonify({})
 
 

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -122,9 +122,8 @@ class InstrumentQueryBackEnd:
 
             self.time_request = None            
                     
-            if self.par_dic.get('time_request', None) is not None:
-                self.time_request = float(self.par_dic['time_request'])
-                self.par_dic.pop('time_request')
+            if self.par_dic.get('time_request', None) not in [ None, 'None' ]:
+                self.time_request = float(self.par_dic.pop('time_request'))
             else:
                 self.time_request = g.get('request_start_time', None)
 

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -120,8 +120,9 @@ class InstrumentQueryBackEnd:
 
             self.set_session_id()
 
-            self.time_request = None
-            if 'time_request' in self.par_dic:
+            self.time_request = None            
+                    
+            if self.par_dic.get('time_request', None) is not None:
                 self.time_request = float(self.par_dic['time_request'])
                 self.par_dic.pop('time_request')
             else:

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -1392,9 +1392,17 @@ class InstrumentQueryBackEnd:
                    request_url=""):
         server = None
         self.logger.info("Sending email")
-        time_request_str = None
+        # Create the plain-text and HTML version of your message,
+        # since emails with HTML content might be, sometimes, not supported
+        # a plain-text version is included
+        text = f"""Update of the task for the instrument {instrument}:\n* status {status}\nProducts url {request_url}"""
+        html = f"""<html><body><p>Update of the task for the instrument {instrument}:<br><ul><li>status {status}</li></ul>Products url {request_url}</p></body></html>"""
+
         if time_request:
             time_request_str = time_.strftime('%Y-%m-%d %H:%M:%S', time_.localtime(float(time_request)))
+            text = f"""Update of the task submitted at {time_request_str}, for the instrument {instrument}:\n* status {status}\nProducts url {request_url}"""
+            html = f"""<html><body><p>Update of the task submitted at {time_request_str}, for the instrument {instrument}:<br><ul><li>status {status}</li></ul>Products url {request_url}</p></body></html>"""
+
         try:
             # send the mail with the status update to the mail provided with the token
             # eg done/failed/submitted
@@ -1411,12 +1419,6 @@ class InstrumentQueryBackEnd:
             message["From"] = sender_email_address
             message["To"] = receiver_email_address
             message["CC"] = ", ".join(cc_receivers_email_addresses)
-
-            # Create the plain-text and HTML version of your message,
-            # since enails with HTML content might be, sometimes, not supportenot
-            # a plain-text version is included
-            text = f"""Update of the task submitted at {time_request_str}, for the instrument {instrument}:\n* status {status}\nProducts url {request_url}"""
-            html = f"""<html><body><p>Update of the task submitted at {time_request_str}, for the instrument {instrument}:<br><ul><li>status {status}</li></ul>Products url {request_url}</p></body></html>"""
 
             part1 = MIMEText(text, "plain")
             part2 = MIMEText(html, "html")

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -124,8 +124,8 @@ class InstrumentQueryBackEnd:
                     
             if self.par_dic.get('time_request', None) not in [ None, 'None' ]:
                 self.time_request = float(self.par_dic.pop('time_request'))
-            else:
-                self.time_request = g.get('request_start_time', None)
+            # else:
+            #     self.time_request = g.get('request_start_time', None)
 
             # By default, a request is public, let's now check if a token has been included
             # In that case, validation is needed
@@ -1388,12 +1388,12 @@ class InstrumentQueryBackEnd:
 
     def send_email(self, status="done",
                    instrument="",
-                   time_request="",
+                   time_request=None,
                    request_url=""):
         server = None
         self.logger.info("Sending email")
-        time_request_str = ""
-        if time_request != "":
+        time_request_str = None
+        if time_request:
             time_request_str = time_.strftime('%Y-%m-%d %H:%M:%S', time_.localtime(float(time_request)))
         try:
             # send the mail with the status update to the mail provided with the token

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -132,7 +132,7 @@ class InstrumentQueryBackEnd:
             self.public = True
             self.token = None
             self.decoded_token = None
-            if 'token' in self.par_dic.keys() and self.par_dic['token'] != "":
+            if 'token' in self.par_dic.keys() and self.par_dic['token'] not in ["", None]:
                 self.token = self.par_dic['token']
                 self.public = False
                 # token validation and decoding can be done here, to check if the token is expired
@@ -532,8 +532,6 @@ class InstrumentQueryBackEnd:
                        getattr(self.config, 'bind_port', None))
 
     def run_call_back(self, status_kw_name='action') -> typing.Tuple[str, typing.Union[QueryOutput, None]]:
-        query_out = None
-
         self.config, self.config_data_server = self.set_config()
         if self.config.sentry_url is not None:
             self.set_sentry_client(self.config.sentry_url)

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -155,8 +155,9 @@ def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_l
 
 
 @pytest.mark.parametrize("default_values", [True, False])
-def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_local_mail_server, default_values):
->>>>>>> d33b3be25e99e64dd854a2e7e57a6198f3079f71
+@pytest.mark.parametrize("time_request_none", [True, False])
+def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_local_mail_server, default_values, time_request_none):
+# >>>>>>> d33b3be25e99e64dd854a2e7e57a6198f3079f71
     # TODO: for now, this is not very different from no-prior-run_analysis. This will improve
 
     server = dispatcher_live_fixture
@@ -300,8 +301,9 @@ def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_l
         f = open(job_monitor_call_back_done_json_fn_aliased)
 
     jdata = json.load(f)
-    if default_values:
-        # email not supposed to be sent (request is short)
+    if default_values or time_request_none:
+        # email not supposed to be sent because request is too short
+        # or the time of the original request was not sent
         assert 'email_status' not in jdata
     else:
         assert jdata['email_status'] == 'email sent'
@@ -361,7 +363,7 @@ def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_l
     assert os.path.exists(smtp_server_log)
     f_local_smtp = open(smtp_server_log)
     f_local_smtp_jdata = json.load(f_local_smtp)
-    if default_values:
+    if default_values or time_request_none:
         assert len(f_local_smtp_jdata) == 2
         assert f_local_smtp_jdata[1]['mail_from'] == 'team@odahub.io'
         assert f_local_smtp_jdata[1]['rcpt_tos'] == ['mtm@mtmco.net', 'team@odahub.io']

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -208,9 +208,14 @@ def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_l
     dict_param_complete.pop('time_request')
     
     request_url = '%s?%s' % ('http://www.astro.unige.ch/cdci/astrooda_', urlencode(dict_param_complete))
-    # email content in text and hmtl format
-    plain_text_email = "Update of the task submitted at {time_request_str}, for the instrument empty-async:\n* status {status}\nProducts url {request_url}"
-    html_text_email = "<html><body><p>Update of the task submitted at {time_request_str}, for the instrument empty-async:<br><ul><li>status {status}</li></ul>Products url {request_url}</p></body></html>"""
+    # email content in text and html format
+    if time_request_none:
+        plain_text_email = "Update of the task for the instrument empty-async:\n* status {status}\nProducts url {request_url}"
+        html_text_email = "<html><body><p>Update of the task for the instrument empty-async:<br><ul><li>status {status}</li></ul>Products url {request_url}</p></body></html>"""
+    else:
+        plain_text_email = "Update of the task submitted at {time_request_str}, for the instrument empty-async:\n* status {status}\nProducts url {request_url}"
+        html_text_email = "<html><body><p>Update of the task submitted at {time_request_str}, for the instrument empty-async:<br><ul><li>status {status}</li></ul>Products url {request_url}</p></body></html>"""
+
     job_monitor_json_fn = f'scratch_sid_{session_id}_jid_{job_id}/job_monitor.json'
     # the aliased version might have been created
     job_monitor_json_fn_aliased = f'scratch_sid_{session_id}_jid_{job_id}_aliased/job_monitor.json'

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -87,8 +87,9 @@ def test_public_async_request(dispatcher_live_fixture, dispatcher_local_mail_ser
     assert 'email_status' not in jdata['exit_status']
 
 
-@pytest.mark.parametrize("default_values", [True, False])
-def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_local_mail_server, default_values):
+@pytest.mark.parametrize("default_values", [(True), False])
+@pytest.mark.parametrize("time_request_none", [True, False])
+def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_local_mail_server, default_values, time_request_none):
     # TODO: for now, this is not very different from no-prior-run_analysis. This will improve
 
     server = dispatcher_live_fixture
@@ -106,7 +107,13 @@ def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_l
         token_payload.pop('mssub')
 
     # set the time the request was initiated
-    time_request = time.time()
+    if time_request_none:
+        time_request = None
+        time_request_str = 'None'
+    else:
+        time_request = time.time() 
+        time_request_str = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(float(time_request)))
+
     encoded_token = jwt.encode(token_payload, secret_key, algorithm='HS256')
     dict_param = dict(
         query_status="new",
@@ -132,7 +139,7 @@ def test_email_callback_after_run_analysis(dispatcher_live_fixture, dispatcher_l
     dict_param_complete = dict_param.copy()
     dict_param_complete['session_id'] = session_id
     dict_param_complete.pop('time_request')
-    time_request_str = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(float(time_request)))
+    
     request_url = '%s?%s' % ('http://www.astro.unige.ch/cdci/astrooda_', urlencode(dict_param_complete))
     # email content in text and hmtl format
     plain_text_email = "Update of the task submitted at {time_request_str}, for the instrument empty-async:\n* status {status}\nProducts url {request_url}"


### PR DESCRIPTION
I attempted to make a test, but it's not complete.

Could you please have a look?
I think the problem is more or less clear, `token='None'` and `time_request='None'` appear in callbacks for public request, and cause trouble in the constructor (ValueError on converting time to float, jwt.exceptions.DecodeError for token).


