### PR TITLE
dict for factories

### DIFF
--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -754,12 +754,18 @@ class InstrumentQueryBackEnd:
         if instrument_name == 'mock':
             new_instrument = 'mock'
         else:
-            for instrument_factory in importer.instrument_factory_list:
-                instrument = instrument_factory()
-                if instrument.name == instrument_name:
+            # for instrument_factory in importer.instrument_factory_list:
+            #     instrument = instrument_factory()
+            #     if instrument.name == instrument_name:
+            #         new_instrument = instrument  # multiple assignment? TODO
+            #
+            #     known_instruments.append(instrument.name)
+            for instrument_factory_name in importer.instrument_name_dict.keys():
+                if instrument_factory_name == instrument_name:
+                    instrument = importer.instrument_name_dict[instrument_factory_name]()
                     new_instrument = instrument  # multiple assignment? TODO
 
-                known_instruments.append(instrument.name)
+                known_instruments.append(instrument_factory_name)
 
         if new_instrument is None:
             raise InstrumentNotRecognized(f'instrument: "{instrument_name}", known: {known_instruments}')

--- a/cdci_data_analysis/plugins/importer.py
+++ b/cdci_data_analysis/plugins/importer.py
@@ -55,16 +55,20 @@ cdci_plugins_dict = {
 }
 
 instrument_factory_list = []
+instrument_name_dict = {}
 # pre-load the empty instrument factory
 
 instrument_factory_list.append(empty_instrument.my_instr_factory)
 instrument_factory_list.append(empty_async_instrument.my_instr_factory)
+instrument_name_dict['empty'] = empty_instrument.my_instr_factory
+instrument_name_dict['empty-async'] = empty_async_instrument.my_instr_factory
 
 for plugin_name in cdci_plugins_dict:
     logger.info("found plugin: %s", plugin_name)
 
     try:
         e = importlib.import_module(plugin_name+'.exposer')
+        instrument_name_dict.update(e.instr_name_dict)
         instrument_factory_list.extend(e.instr_factory_list)
         logger.info(render('{GREEN}imported plugin: %s{/}'), plugin_name)
 


### PR DESCRIPTION
Instead of the list of factories, a dictionary pairing the name of the instrument and the relative factory is provided.

set_instrument calls the factory only for the needed instrument