### PR TITLE
products_url for output api_code

### DIFF
--- a/cdci_data_analysis/analysis/instrument.py
+++ b/cdci_data_analysis/analysis/instrument.py
@@ -252,7 +252,8 @@ class Instrument:
 
         # adding query parameters to final products
         query_out.set_analysis_parameters(par_dic)
-        query_out.set_api_code(par_dic, url=f'http://{job.dispatcher_host}:{job.dispatcher_port}')
+        # TODO perhaps this will change
+        query_out.set_api_code(par_dic, url=back_end_query.config.products_url)
         query_out.dump_analysis_parameters(out_dir, par_dic)
 
         return query_out


### PR DESCRIPTION
instead of the bind_host and bind_port

tests for `oda_api` will also be adapted