### PR TITLE
More clear message

### DIFF
--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -445,7 +445,7 @@ class InstrumentQueryBackEnd:
                 if not self.public:
                     debug_message += " for your user account email"
                 logstash_message(self.app, {'origin': 'dispatcher-call-back', 'event': 'unauthorized-user'})
-                raise RequestNotAuthorized("user not authorized to download the requested product", debug_message=debug_message)
+                raise RequestNotAuthorized("Request not authorized", debug_message=debug_message)
 
     def download_products(self,):
         try:

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -446,7 +446,7 @@ class InstrumentQueryBackEnd:
                 if not self.public:
                     debug_message += " for your user account email"
                 logstash_message(self.app, {'origin': 'dispatcher-call-back', 'event': 'unauthorized-user'})
-                raise RequestNotAuthorized("user not authorized to download the requested product", debug_message=debug_message)
+                raise RequestNotAuthorized("Request not authorized", debug_message=debug_message)
 
     def download_products(self,):
         try:

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -231,10 +231,6 @@ class InstrumentQueryBackEnd:
         # this takes care of various strange objects which can not be properly represented
         return format_hash(json.dumps(o))
 
-    def calculate_job_id(self, par_dic):
-        return u'%s' % (self.make_hash(par_dic))
-
-    # not job_id??
     def generate_job_id(self, kw_black_list=['session_id', 'job_id', 'token']):
         self.logger.info("\033[31m---> GENERATING JOB ID <---\033[0m")
         self.logger.info(
@@ -257,7 +253,7 @@ class InstrumentQueryBackEnd:
             # token has not been considered, but the user id will be (if availaable)
             _dict['sub'] = tokenHelper.get_token_user_email_address(self.decoded_token)
 
-        self.job_id = self.calculate_job_id(_dict)
+        self.job_id = u'%s' % (self.make_hash(_dict))
 
         self.logger.info(
             '\033[31mgenerated NEW job_id %s \033[0m', self.job_id)
@@ -435,9 +431,9 @@ class InstrumentQueryBackEnd:
                     **request_par_dic,
                     "sub": tokenHelper.get_token_user_email_address(self.decoded_token)
                 }
-                calculated_job_id = self.calculate_job_id(dict_job_id)
+                calculated_job_id = u'%s' % (self.make_hash(dict_job_id))
             else:
-                calculated_job_id = self.calculate_job_id(request_par_dic)
+                calculated_job_id = u'%s' % (self.make_hash(request_par_dic))
 
             if self.job_id != calculated_job_id:
                 debug_message = f"The provided job_id={self.job_id} does not match with the job_id={calculated_job_id} " \

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -279,7 +279,7 @@ def test_validation_job_id(dispatcher_live_fixture):
            f'The provided job_id={dispatcher_job_state.job_id} does not match with the ' \
            f'job_id={wrong_job_id} derived from the request parameters for your user account email'
     assert jdata["exit_status"]["error_message"] == ""
-    assert jdata["exit_status"]["message"] == "user not authorized to download the requested product"
+    assert jdata["exit_status"]["message"] == "Request not authorized"
 
 
 @pytest.mark.parametrize("default_values", [True, False])

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -338,7 +338,7 @@ def test_download_products_unauthorized_user(dispatcher_live_fixture, empty_prod
            f'The provided job_id={job_id} does not match with the ' \
            f'job_id={wrong_job_id} derived from the request parameters for your user account email'
     assert jdata["exit_status"]["error_message"] == ""
-    assert jdata["exit_status"]["message"] == "user not authorized to download the requested product"
+    assert jdata["exit_status"]["message"] == "Request not authorized"
 
 
 @pytest.mark.not_safe_parallel


### PR DESCRIPTION
Before it was related to the download of a product, now is more general, since the validation of the `job_id` happens both during a download as well as when `run_analysys`