### PR TITLE
validate response schema

### DIFF
--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -284,6 +284,8 @@ def run_analysis():
         logger.info("towards log_run_query_result")
         log_run_query_result(request_summary, r[0])
 
+        QueryOutJSON().load(r[0].json)
+
         return r
     except APIerror as e:
         raise

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -7,12 +7,9 @@ Created on Wed May 10 10:55:20 2017
 """
 from builtins import (open, str, range,
                       object)
-from collections import Counter, OrderedDict
-import copy
 from werkzeug.utils import secure_filename
 
 import os
-import glob
 import string
 import random
 from raven.contrib.flask import Sentry
@@ -22,23 +19,15 @@ import traceback
 from flask import jsonify, send_from_directory, redirect, Response
 from flask import Flask, request, make_response, abort, g
 from flask.json import JSONEncoder
-from flask_restx import Api, Resource, reqparse
 
 # restx not really used
-# we could do validation and API generation with this, but let's not yet
-#from flasgger import Swagger, SwaggerView, Schema, fields # type: ignore
-from marshmallow import Schema, fields # type: ignore
-from marshmallow.validate import OneOf # type: ignore
+from flask_restx import Api, Resource, reqparse
 
-
-import tempfile
-import tarfile
-import gzip
 import logging
-import socket
 import time as _time
 
 from .logstash import logstash_message
+from .schemas import QueryOutJSON
 
 from ..plugins import importer
 
@@ -230,24 +219,6 @@ def common_exception_payload():
 
     return payload
 
-
-class ExitStatus(Schema):
-    status = fields.Int(validate=OneOf([0, 1]))
-    message = fields.Str(description="if query_status == 'failed', shown in waitingDialog in red")     
-    error_message = fields.Str(description="if query_status == 'failed', shown in waitingDialog in red")     
-    debug_message = fields.Str(description="if query_status == 'done' but exit_status.status != 0, shown in waitingDialog in red")     
-    comment = fields.Str(description="always, shown in waitingDialog in yellow")     
-    warning = fields.Str(description="")     
-    
-
-class QueryOutJSON(Schema):
-    query_status = fields.Str(
-                        validate=OneOf(["done", "failed", "submitted"]),
-                        description=""
-                    )
-    exit_status = ExitStatus
-    session_id = fields.Str()
-    job_id = fields.Str()
 
 
 @app.route('/run_analysis', methods=['POST', 'GET'])

--- a/cdci_data_analysis/flask_app/schemas.py
+++ b/cdci_data_analysis/flask_app/schemas.py
@@ -3,6 +3,7 @@ from marshmallow.validate import OneOf
 
 class ExitStatus(Schema):
     class Meta:
+        # TODO: adapt and remove this, so that only what is consumed by frontend is sent
         unknown = EXCLUDE
 
     status = fields.Int(validate=OneOf([0, 1]), required=True)

--- a/cdci_data_analysis/flask_app/schemas.py
+++ b/cdci_data_analysis/flask_app/schemas.py
@@ -24,6 +24,6 @@ class QueryOutJSON(Schema):
                     )
 
     exit_status = fields.Nested(ExitStatus, required=True)
-    session_id = fields.Str(required=True)
-    job_id = fields.Str(required=True)
+    session_id = fields.Str(required=False) # is it required?
+    job_id = fields.Str(required=False) # is it required?
 

--- a/cdci_data_analysis/flask_app/schemas.py
+++ b/cdci_data_analysis/flask_app/schemas.py
@@ -28,3 +28,9 @@ class QueryOutJSON(Schema):
     session_id = fields.Str(required=False) # is it required?
     job_id = fields.Str(required=False) # is it required?
 
+    error_message = fields.Str(
+                        validate=OneOf([""]),
+                        description="",
+                        required=False # but if present, should be empty
+                    )
+

--- a/cdci_data_analysis/flask_app/schemas.py
+++ b/cdci_data_analysis/flask_app/schemas.py
@@ -1,0 +1,29 @@
+from marshmallow import Schema, EXCLUDE, fields
+from marshmallow.validate import OneOf
+
+class ExitStatus(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    status = fields.Int(validate=OneOf([0, 1]), required=True)
+    message = fields.Str(description="if query_status == 'failed', shown in waitingDialog in red", required=True)
+    error_message = fields.Str(description="if query_status == 'failed', shown in waitingDialog in red", required=True)
+    debug_message = fields.Str(description="if query_status == 'done' but exit_status.status != 0, shown in waitingDialog in red", required=True)
+    comment = fields.Str(description="always, shown in waitingDialog in yellow", required=True)
+    warning = fields.Str(description="", required=True)
+
+
+class QueryOutJSON(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    query_status = fields.Str(
+                        validate=OneOf(["done", "failed", "submitted"]),
+                        description="",
+                        required=True
+                    )
+
+    exit_status = fields.Nested(ExitStatus, required=True)
+    session_id = fields.Str(required=True)
+    job_id = fields.Str(required=True)
+


### PR DESCRIPTION
if response schema is not maintained, frontend will not show expected messages

what is currently expected by frontend is specified in the schema with explanations in comments:

https://github.com/oda-hub/dispatcher-app/blob/master/cdci_data_analysis/flask_app/app.py#L234

The frontend assumptions on response are deduced from frontend-astrooda code.

this would help https://github.com/oda-hub/dispatcher-app/issues/146