### PR TITLE
to suppress email submission completely with token config

### DIFF
--- a/cdci_data_analysis/analysis/email_helper.py
+++ b/cdci_data_analysis/analysis/email_helper.py
@@ -379,10 +379,10 @@ def is_email_to_send_callback(logger, status, time_original_request, config, job
                 logger.info("number of done emails sent: %s", len(done_email_files))
                 raise MultipleDoneEmail("multiple completion email detected")
 
-            return  tokenHelper.get_token_user_done_email() and email_sending_timeout and duration_query > timeout_threshold_email
+            return  tokenHelper.get_token_user_done_email(decoded_token) and email_sending_timeout and duration_query > timeout_threshold_email
 
         # or if failed
         elif status == 'failed':
-            return tokenHelper.get_token_user_fail_email()
+            return tokenHelper.get_token_user_fail_email(decoded_token)
 
     return False

--- a/cdci_data_analysis/analysis/email_helper.py
+++ b/cdci_data_analysis/analysis/email_helper.py
@@ -379,10 +379,10 @@ def is_email_to_send_callback(logger, status, time_original_request, config, job
                 logger.info("number of done emails sent: %s", len(done_email_files))
                 raise MultipleDoneEmail("multiple completion email detected")
 
-            return email_sending_timeout and duration_query > timeout_threshold_email
+            return  tokenHelper.get_token_user_done_email() and email_sending_timeout and duration_query > timeout_threshold_email
 
         # or if failed
         elif status == 'failed':
-            return True
+            return tokenHelper.get_token_user_fail_email()
 
     return False

--- a/cdci_data_analysis/analysis/tokenHelper.py
+++ b/cdci_data_analysis/analysis/tokenHelper.py
@@ -56,23 +56,3 @@ def get_decoded_token(token, secret_key):
     # decode the encoded token
     if token is not None:
         return jwt.decode(token, secret_key, algorithms=[default_algorithm])
-
-def update_token(token, secret_key, payload_mutation: FunctionType):
-    token_payload = jwt.decode(token, secret_key, algorithms=[default_algorithm])    
-
-    # update here
-    # tem=300000
-
-    token_payload = payload_mutation(token_payload) 
-
-    out_token = jwt.encode(token_payload, secret_key, algorithm=default_algorithm)
-
-    return out_token
-
-def update_token_suppress_email(token, secret_key):
-    def payload_mutation(token_payload):
-        token_payload['mssub'] = False
-        token_payload['msdone'] = False 
-        token_payload['msfail'] = False 
-
-    return update_token(token, secret_key, payload_mutation)

--- a/cdci_data_analysis/analysis/tokenHelper.py
+++ b/cdci_data_analysis/analysis/tokenHelper.py
@@ -1,5 +1,7 @@
+from types import FunctionType
 import jwt
 
+default_algorithm = 'HS256'
 
 def get_token_roles(decoded_token):
     # extract role(s)
@@ -42,11 +44,35 @@ def get_token_user_sending_submitted_interval_email(decoded_token):
 
 
 def get_token_user_submitted_email(decoded_token):
-    # extract user threshold
     return decoded_token['mssub'] if 'mssub' in decoded_token else None
 
+def get_token_user_done_email(decoded_token):
+    return decoded_token.get('msdone', True) # TODO: make server configurable
+
+def get_token_user_fail_email(decoded_token):
+    return decoded_token.get('msfail', True) # TODO: make server configurable
 
 def get_decoded_token(token, secret_key):
     # decode the encoded token
     if token is not None:
-        return jwt.decode(token, secret_key, algorithms=['HS256'])
+        return jwt.decode(token, secret_key, algorithms=[default_algorithm])
+
+def update_token(token, secret_key, payload_mutation: FunctionType):
+    token_payload = jwt.decode(token, secret_key, algorithms=[default_algorithm])    
+
+    # update here
+    # tem=300000
+
+    token_payload = payload_mutation(token_payload) 
+
+    out_token = jwt.encode(token_payload, secret_key, algorithm=default_algorithm)
+
+    return out_token
+
+def update_token_suppress_email(token, secret_key):
+    def payload_mutation(token_payload):
+        token_payload['mssub'] = False
+        token_payload['msdone'] = False 
+        token_payload['msfail'] = False 
+
+    return update_token(token, secret_key, payload_mutation)

--- a/tests/reference_emails/submitted.html
+++ b/tests/reference_emails/submitted.html
@@ -2,13 +2,13 @@
 <html lang="en">
 
 <head>
-    <title>[ODA][submitted] dummy first requested at 2021-06-09 18:20:28 job_id: 2a8eb39e</title>
+    <title>[ODA][submitted] dummy first requested at 2021-07-22 15:37:33 job_id: ac3f746e</title>
 </head>
 
 <body>
 Dear User,<br>
 <br>
-you receive this message because at 2021-06-09 18:20:28 ( 0.1 seconds ago ) you submitted a request <br>
+you receive this message because at 2021-07-22 15:37:33 ( 0.0 seconds ago ) you submitted a request <br>
 for a dummy from the service provided by University of Geneva<br>
 available at the URL PRODUCTS_URL.<br>
 <br>
@@ -16,9 +16,11 @@ available at the URL PRODUCTS_URL.<br>
 Once products will be ready, you will receive a new email.<br>
 
 <br>
+
 You can inspect the status of your job using the following <a href="PRODUCTS_URL?query_status=new&query_type=Real&instrument=empty-async&product_type=dummy">url</a>.<br>
- 
+
 Note that this url is permanent, and can be used to refer to the results as long as the service exists.<br>
+
 
 You can also retrieve the result by repeating the request (either with frontend or with the python API query at the end of this message.).<br>
 <br>
@@ -34,7 +36,7 @@ Python API code:<br>
 <div style="background-color: lightgray; display: inline-block; padding: 5px;">
 from oda_api.api import DispatcherAPI<br>
 <br>
-disp = DispatcherAPI(url=&#34;PRODUCTS_URL&#34;, instrument=&#34;mock&#34;)<br>
+disp = DispatcherAPI(url=&#34;PRODUCTS_URL/dispatch-data&#34;, instrument=&#34;mock&#34;)<br>
 <br>
 par_dict = {<br>
     &#34;product_type&#34;: &#34;Real&#34;,<br>
@@ -42,7 +44,7 @@ par_dict = {<br>
     &#34;product&#34;: &#34;dummy&#34;,<br>
     &#34;token&#34;: (<br>
         &#34;eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdG1AbXRtY28ubmV0IiwibmFtZSI6Im1tZWhhcmdhIiwicm9sZX&#34;<br>
-        &#34;MiOiJnZW5lcmFsIiwiZXhwIjoxNjIzMjYwNjI0fQ.d7h8ndgfER8Gt208nkB8FQUizLfv9WzU8jBeCBLktFM&#34;<br>
+        &#34;MiOiJnZW5lcmFsIiwiZXhwIjoxNjI2OTY2MDQ4fQ.hvxxsEGdmXQsZovWHZtAQNHw4ZrTKfHSmOjWPFYPiho&#34;<br>
     ),<br>
 }<br>
 <br>
@@ -52,7 +54,7 @@ data_collection = disp.get_product(**par_dict)<br>
 <br>
 <br>
 Note that this code contains your private token. Be careful how you share it!<br>
-This token is short-lived, and will expire in 83.3 minutes.<br>
+This token is short-lived, and will expire in 83.2 minutes.<br>
 To learn how to get a new token, please refer to <a href="possibly-non-site-specific-link">these instructions</a>.<br>
 <br>
 

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -473,6 +473,10 @@ def test_email_oda_api(dispatcher_live_fixture, dispatcher_local_mail_server):
         **default_token_payload
     }
     encoded_token = jwt.encode(token_payload, secret_key, algorithm='HS256')
+    
+    if isinstance(encoded_token, bytes):
+        encoded_token = encoded_token.decode()
+
 
     disp = oda_api.api.DispatcherAPI(
         url=dispatcher_live_fixture,
@@ -538,6 +542,9 @@ def test_valid_token_oda_api(dispatcher_live_fixture):
         **default_token_payload
     }
     encoded_token = jwt.encode(token_payload, secret_key, algorithm='HS256')
+    
+    if isinstance(encoded_token, bytes):
+        encoded_token = encoded_token.decode()
 
     disp = oda_api.api.DispatcherAPI(
         url=dispatcher_live_fixture)
@@ -828,6 +835,10 @@ def test_user_catalog_oda_api(dispatcher_live_fixture):
         "roles": "unige-hpc-full, general",
     }
     encoded_token = jwt.encode(token_payload, secret_key, algorithm='HS256')
+
+    if isinstance(encoded_token, bytes):
+        encoded_token = encoded_token.decode()
+
     selected_catalog_dict = dict(
         cat_lon_name="ra",
         cat_lat_name="dec",


### PR DESCRIPTION
I will generate the token elsewhere, but I need this suppression for larger analysises I run.