### PR TITLE
dedicated error_message from drupal_helper

### DIFF
--- a/cdci_data_analysis/analysis/drupal_helper.py
+++ b/cdci_data_analysis/analysis/drupal_helper.py
@@ -236,7 +236,7 @@ def execute_drupal_request(url,
                                "please check it and try to issue again the request")
                 drupal_helper_error_message = res.text
                 # handling specific case of a not recognized/invalid argument
-                m = re.search('<em (.*)>InvalidArgumentException</em>:(.*)</em>\)', res.text)
+                m = re.search(r'<em(.*)>InvalidArgumentException</em>:(.*)</em>\)', res.text)
                 if m is not None:
                     drupal_helper_error_message = re.sub('<[^<]+?>', '', m.group())
 

--- a/cdci_data_analysis/analysis/drupal_helper.py
+++ b/cdci_data_analysis/analysis/drupal_helper.py
@@ -7,6 +7,7 @@ import base64
 import copy
 import uuid
 import glob
+import re
 
 from typing import Optional, Tuple, Dict
 from dateutil import parser, tz
@@ -233,9 +234,15 @@ def execute_drupal_request(url,
                                f"the requested url {url} lead to the error {res.text}, "
                                "this might be due to an error in the url or the page requested no longer exists, "
                                "please check it and try to issue again the request")
+                drupal_helper_error_message = res.text
+                # handling specific case of a not recognized/invalid argument
+                m = re.search('<em (.*)>InvalidArgumentException</em>:(.*)</em>\)', res.text)
+                if m is not None:
+                    drupal_helper_error_message = re.sub('<[^<]+?>', '', m.group())
+
                 raise InternalError('issue when performing a request to the product gallery',
                                     status_code=500,
-                                    payload={'drupal_helper_error_message': res.text})
+                                    payload={'drupal_helper_error_message': drupal_helper_error_message})
             else:
                 total_n_successful_post_requests += 1
 

--- a/cdci_data_analysis/analysis/drupal_helper.py
+++ b/cdci_data_analysis/analysis/drupal_helper.py
@@ -235,7 +235,7 @@ def execute_drupal_request(url,
                                "please check it and try to issue again the request")
                 raise InternalError('issue when performing a request to the product gallery',
                                     status_code=500,
-                                    payload={'error_message': res.text})
+                                    payload={'drupal_helper_error_message': res.text})
             else:
                 total_n_successful_post_requests += 1
 

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -1986,7 +1986,8 @@ def test_product_gallery_error_message(dispatcher_live_fixture_with_gallery):
     drupal_res_obj = c.json()
 
     assert 'drupal_helper_error_message' in drupal_res_obj
-    assert 'Field field_e3_kev is unknown.' in drupal_res_obj['drupal_helper_error_message']
+    assert 'InvalidArgumentException: Field field_e3_kev is unknown.' \
+           in drupal_res_obj['drupal_helper_error_message']
 
 
 @pytest.mark.test_renku

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -1950,6 +1950,45 @@ def test_product_gallery_update(dispatcher_live_fixture_with_gallery, dispatcher
     assert len(drupal_res_obj['_links'][link_fits_file_id]) == 1
 
 
+@pytest.mark.test_drupal
+def test_product_gallery_error_message(dispatcher_live_fixture_with_gallery):
+    dispatcher_fetch_dummy_products('default')
+
+    server = dispatcher_live_fixture_with_gallery
+
+    logger.info("constructed server: %s", server)
+
+    # send simple request
+    # let's generate a valid token
+    token_payload = {
+        **default_token_payload,
+        "roles": "general, gallery contributor",
+    }
+    encoded_token = jwt.encode(token_payload, secret_key, algorithm='HS256')
+
+    e1_kev = 45
+    e2_kev = 95
+
+    params = {
+        'content_type': 'data_product',
+        'E1_keV': e1_kev,
+        'E2_kev': e2_kev,
+        'E3_kev': 123,
+        'token': encoded_token
+    }
+
+    c = requests.post(os.path.join(server, "post_product_to_gallery"),
+                      params={**params},
+                      )
+
+    assert c.status_code == 500
+
+    drupal_res_obj = c.json()
+
+    assert 'drupal_helper_error_message' in drupal_res_obj
+    assert 'Field field_e3_kev is unknown.' in drupal_res_obj['drupal_helper_error_message']
+
+
 @pytest.mark.test_renku
 @pytest.mark.parametrize("existing_branch", [True, False])
 @pytest.mark.parametrize("scw_list_passage", ['file', 'params'])


### PR DESCRIPTION
It is good to have a specific field to see the error message from drupal.

Currently, it is created an `error_message` entry, that will be then overwritten by the dispatcher before returning the exception

