### PR TITLE
Optimisations in Instrument lists

### DIFF
--- a/cdci_data_analysis/analysis/instrument.py
+++ b/cdci_data_analysis/analysis/instrument.py
@@ -793,3 +793,13 @@ def build_catalog(cat_dic,catalog_selected_objects=None):
     user_catalog.select_IDs(IDs)
 
     return user_catalog
+
+class InstrumentFactoryIterator:
+    def __init__(self):
+        self._partlist = []
+        
+    def extend(self, lst):
+        self._partlist.append(lst)
+    
+    def __iter__(self):
+        return (y for x in self._partlist for y in x)

--- a/cdci_data_analysis/analysis/parameters.py
+++ b/cdci_data_analysis/analysis/parameters.py
@@ -496,7 +496,7 @@ class Parameter:
             par_format = par_unit = allowed_values = min_value = max_value = None
         else:
             if ontology_path is not None:
-                if isinstance(ontology_path, str) or isinstance(ontology_path, os.PathLike):
+                if isinstance(ontology_path, (str, os.PathLike)):
                     onto = Ontology(ontology_path)
                 else:
                     raise RuntimeError("Wrong ontology_path")

--- a/cdci_data_analysis/analysis/parameters.py
+++ b/cdci_data_analysis/analysis/parameters.py
@@ -483,17 +483,6 @@ class Parameter:
                      extra_ttl = None,
                      ontology_path = None, 
                      **kwargs):
-        return cls.instance_signature_from_owl_uri(owl_uri,
-                                                   extra_ttl,
-                                                   ontology_path, 
-                                                   **kwargs)[0]
-
-    @classmethod
-    def instance_signature_from_owl_uri(cls,
-                                        owl_uri,
-                                        extra_ttl = None,
-                                        ontology_path = None, 
-                                        **kwargs):
         from oda_api.ontology_helper import Ontology
 
         if ontology_path is None:
@@ -555,7 +544,7 @@ class Parameter:
                                         par_name, par_value, python_subclass, call_signature)
                     try:
                         parameter_interpretation = python_subclass(**call_kwargs)
-                        return parameter_interpretation, python_subclass, call_kwargs
+                        return parameter_interpretation
                     except Exception as e:
                         logger.exception(("owl_uri %s matches Parameter %s, but the Parameter constructor failed! "
                                           "Possibly a programming error"), 
@@ -563,8 +552,8 @@ class Parameter:
 
         logger.warning(('Unknown owl type uri %s or failed to construct any parameter. '
                         'Creating basic Parameter object.'), owl_uri)
-        return cls(**kwargs), cls, kwargs
-
+        return cls(**kwargs)
+    
 class String(Parameter):
     owl_uris = ("http://www.w3.org/2001/XMLSchema#str", "http://odahub.io/ontology#String")
     

--- a/cdci_data_analysis/analysis/parameters.py
+++ b/cdci_data_analysis/analysis/parameters.py
@@ -494,17 +494,17 @@ class Parameter:
                 'extra_ttl will be ignored ', owl_uri)
             parameter_hierarchy = [ owl_uri ]
             par_format = par_unit = allowed_values = min_value = max_value = None
-        elif ontology_path is not None:
-            if isinstance(ontology_path, str) or isinstance(ontology_path, os.PathLike):
-                onto = Ontology(ontology_path)
-            else:
-                raise RuntimeError("Wrong ontology_path")
         else:
-            if isinstance(ontology_object, Ontology):
-                onto = ontology_object
+            if ontology_path is not None:
+                if isinstance(ontology_path, str) or isinstance(ontology_path, os.PathLike):
+                    onto = Ontology(ontology_path)
+                else:
+                    raise RuntimeError("Wrong ontology_path")
             else:
-                raise RuntimeError("Wrong ontology_object")
-            
+                if isinstance(ontology_object, Ontology):
+                    onto = ontology_object
+                else:
+                    raise RuntimeError("Wrong ontology_object")
             
             if extra_ttl is not None:
                 onto.parse_extra_triples(extra_ttl)

--- a/cdci_data_analysis/analysis/parameters.py
+++ b/cdci_data_analysis/analysis/parameters.py
@@ -482,22 +482,29 @@ class Parameter:
                      owl_uri,
                      extra_ttl = None,
                      ontology_path = None, 
+                     ontology_object = None,
                      **kwargs):
         from oda_api.ontology_helper import Ontology
 
-        if ontology_path is None:
-            logger.warning('Ontology path not set in Parameter.from_owl_uri(). '
+        if ontology_path is not None and ontology_object is not None:
+            raise RuntimeError("Both ontology_path and ontology_object parameters are set.")
+        elif ontology_path is None and ontology_object is None:
+            logger.warning('Ontology path/object not set in Parameter.from_owl_uri(). '
                 'Trying to find parameter which have %s directly set. '
                 'extra_ttl will be ignored ', owl_uri)
             parameter_hierarchy = [ owl_uri ]
             par_format = par_unit = allowed_values = min_value = max_value = None
-        else:
+        elif ontology_path is not None:
             if isinstance(ontology_path, str) or isinstance(ontology_path, os.PathLike):
                 onto = Ontology(ontology_path)
-            elif isinstance(ontology_path, Ontology):
-                onto = ontology_path
             else:
                 raise RuntimeError("Wrong ontology_path")
+        else:
+            if isinstance(ontology_object, Ontology):
+                onto = ontology_object
+            else:
+                raise RuntimeError("Wrong ontology_object")
+            
             
             if extra_ttl is not None:
                 onto.parse_extra_triples(extra_ttl)

--- a/cdci_data_analysis/analysis/parameters.py
+++ b/cdci_data_analysis/analysis/parameters.py
@@ -482,6 +482,17 @@ class Parameter:
                      extra_ttl = None,
                      ontology_path = None, 
                      **kwargs):
+        return cls.instance_signature_from_owl_uri(owl_uri,
+                                                   extra_ttl,
+                                                   ontology_path, 
+                                                   **kwargs)[0]
+
+    @classmethod
+    def instance_signature_from_owl_uri(cls,
+                                        owl_uri,
+                                        extra_ttl = None,
+                                        ontology_path = None, 
+                                        **kwargs):
         from oda_api.ontology_helper import Ontology
 
         if ontology_path:
@@ -537,7 +548,7 @@ class Parameter:
                                         par_name, par_value, python_subclass, call_signature)
                     try:
                         parameter_interpretation = python_subclass(**call_kwargs)
-                        return parameter_interpretation
+                        return parameter_interpretation, python_subclass, call_kwargs
                     except Exception as e:
                         logger.exception(("owl_uri %s matches Parameter %s, but the Parameter constructor failed! "
                                           "Possibly a programming error"), 
@@ -545,7 +556,7 @@ class Parameter:
 
         logger.warning(('Unknown owl type uri %s or failed to construct any parameter. '
                         'Creating basic Parameter object.'), owl_uri)
-        return cls(**kwargs)
+        return cls(**kwargs), cls, kwargs
 
 class String(Parameter):
     owl_uris = ("http://www.w3.org/2001/XMLSchema#str", "http://odahub.io/ontology#String")

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -207,7 +207,7 @@ def common_exception_payload():
      
     _l = []
 
-    for instrument_factory in importer.instrument_factory_list:
+    for instrument_factory in importer.instrument_factory_iter:
         _l.append('%s' % getattr(instrument_factory, 'instr_name', instrument_factory().name))
 
     payload['installed_instruments'] = _l

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -208,7 +208,7 @@ def common_exception_payload():
     _l = []
 
     for instrument_factory in importer.instrument_factory_iter:
-        _l.append('%s' % getattr(instrument_factory, 'instr_name', instrument_factory().name))
+        _l.append(str(getattr(instrument_factory, 'instr_name', instrument_factory().name)))
 
     payload['installed_instruments'] = _l
 

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -208,7 +208,7 @@ def common_exception_payload():
     _l = []
 
     for instrument_factory in importer.instrument_factory_list:
-        _l.append('%s' % instrument_factory().name)
+        _l.append('%s' % getattr(instrument_factory, 'instr_name', instrument_factory().name))
 
     payload['installed_instruments'] = _l
 

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -446,7 +446,7 @@ class InstrumentQueryBackEnd:
                 email = tokenHelper.get_token_user_email_address(decoded_token)
 
         out_instrument_list = []
-        for instrument_factory in importer.instrument_factory_list:
+        for instrument_factory in importer.instrument_factory_iter:
             if hasattr(instrument_factory, 'instrument_query'):
                 instrument_query = instrument_factory.instrument_query
                 instr_name = getattr(instrument_factory, 'instr_name', instrument_factory().name)
@@ -1112,7 +1112,7 @@ class InstrumentQueryBackEnd:
 
     def get_instr_list(self, name=None):
         _l = []
-        for instrument_factory in importer.instrument_factory_list:
+        for instrument_factory in importer.instrument_factory_iter:
             _l.append(getattr(instrument_factory, 'instr_name', instrument_factory().name))
 
         return jsonify(_l)
@@ -1497,7 +1497,7 @@ class InstrumentQueryBackEnd:
         if instrument_name == 'mock':
             new_instrument = 'mock'
         else:
-            for instrument_factory in importer.instrument_factory_list:
+            for instrument_factory in importer.instrument_factory_iter:
                 _instrument = None
                 if hasattr(instrument_factory, 'instr_name'):
                     instr_name = instrument_factory.instr_name

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -1509,7 +1509,8 @@ class InstrumentQueryBackEnd:
                     if _instrument is None and hasattr(instrument_factory, 'instrument_query'):
                         instr_query = instrument_factory.instrument_query
                     else:
-                        _instrument = instrument_factory()
+                        if _instrument is None:
+                            _instrument = instrument_factory()
                         instr_query = _instrument.instrumet_query
                              
                     if instr_query.check_instrument_access(roles, email):

--- a/cdci_data_analysis/plugins/importer.py
+++ b/cdci_data_analysis/plugins/importer.py
@@ -41,6 +41,7 @@ from pscolors import render
 logger = logging.getLogger(__name__)
 import sys
 from importlib import reload
+from cdci_data_analysis.analysis.instrument import InstrumentFactoryIterator
 
 
 #plugin_list=['cdci_osa_plugin','cdci_polar_plugin']
@@ -56,9 +57,9 @@ cdci_plugins_dict = {
 if os.environ.get('DISPATCHER_DEBUG_MODE', 'no') == 'yes':
     cdci_plugins_dict['dummy_plugin'] = importlib.import_module('.dummy_plugin', 'cdci_data_analysis.plugins')
 
-def build_instrument_factory_list():
+def build_instrument_factory_iter():
     activate_plugins = os.environ.get('DISPATCHER_PLUGINS', 'auto')
-    instr_factory_list = []
+    instr_factory_iter = InstrumentFactoryIterator()
     
     for plugin_name in cdci_plugins_dict:
         if activate_plugins == 'auto' or plugin_name in activate_plugins:   
@@ -66,20 +67,20 @@ def build_instrument_factory_list():
 
             try:
                 e = importlib.import_module('.exposer', cdci_plugins_dict[plugin_name].__name__)
-                instr_factory_list.extend(e.instr_factory_list)
+                instr_factory_iter.extend(e.instr_factory_list)
                 logger.info(render('{GREEN}imported plugin: %s{/}'), plugin_name)
 
             except Exception as e:
                 logger.error('failed to import %s: %s', plugin_name,e )
                 traceback.print_exc()
-    return instr_factory_list
+    return instr_factory_iter
 
-instrument_factory_list = build_instrument_factory_list()
+instrument_factory_iter = build_instrument_factory_iter()
 
 def reload_plugin(plugin_name):
-    global instrument_factory_list
+    global instrument_factory_iter
     if plugin_name not in cdci_plugins_dict.keys():
         raise ModuleNotFoundError(plugin_name)
     reload(cdci_plugins_dict[plugin_name])
     reload(sys.modules[cdci_plugins_dict[plugin_name].__name__+'.exposer'])
-    instrument_factory_list = build_instrument_factory_list()
+    instrument_factory_iter = build_instrument_factory_iter()


### PR DESCRIPTION
This PR is a supporting for https://github.com/oda-hub/dispatcher-plugin-nb2workflow/pull/90

 - `importer.instrument_factory_list` is now an iterator that stores instr_factory_list per-plugin (to properly deal with the new one in nb2w plugin).
- `Parameter.from_owl_url` now accepts `Ontology` object (for optimisation)
- Optimisation. In all iterations over `instrument_factory_list` the `Instrument` object is not built if we don't really need it, instead attributes of the factory function are checked. (Before, all Instrument instances of nb2w plugin were created in every request).