### PR TITLE
Not-Set token uploaded file url

### DIFF
--- a/cdci_data_analysis/analysis/instrument.py
+++ b/cdci_data_analysis/analysis/instrument.py
@@ -251,7 +251,6 @@ class Instrument:
                            bind_port,
                            request_files_dir,
                            decoded_token,
-                           token=None,
                            sentry_dsn=None):
         error_message = 'Error while {step} {temp_dir_content_msg}{additional}'
         # TODO probably exception handling can be further improved and/or optmized
@@ -282,8 +281,7 @@ class Instrument:
                                                     uploaded_files_obj=uploaded_files_obj,
                                                     products_url=products_url,
                                                     bind_host=bind_host,
-                                                    bind_port=bind_port,
-                                                    token=token)
+                                                    bind_port=bind_port)
             step = 'updating ownership files'
             self.update_ownership_files(uploaded_files_obj,
                                         request_files_dir=request_files_dir,
@@ -710,7 +708,7 @@ class Instrument:
             else:
                 raise RuntimeError
 
-    def update_par_dic_with_uploaded_files(self, par_dic, uploaded_files_obj, products_url, bind_host, bind_port, token=None):
+    def update_par_dic_with_uploaded_files(self, par_dic, uploaded_files_obj, products_url, bind_host, bind_port):
         if validators.url(products_url, simple_host=True):
             # TODO remove the dispatch-data part, better to have it extracted from the configuration file
             basepath = os.path.join(products_url, 'dispatch-data/download_file')
@@ -718,8 +716,6 @@ class Instrument:
             basepath = os.path.join(f"http://{bind_host}:{bind_port}", 'download_file')
         for f in uploaded_files_obj:
             dict_args = dict(file_list=uploaded_files_obj[f], _is_mmoda_url=True, return_archive=False)
-            if token is not None:
-                dict_args['token'] = token
             dpars = urlencode(dict_args)
             download_file_url = f"{basepath}?{dpars}"
             par_dic[f] = download_file_url

--- a/cdci_data_analysis/flask_app/dispatcher_query.py
+++ b/cdci_data_analysis/flask_app/dispatcher_query.py
@@ -309,7 +309,6 @@ class InstrumentQueryBackEnd:
                             bind_host=bind_host,
                             bind_port=bind_port,
                             request_files_dir=self.request_files_dir,
-                            token=self.token,
                             decoded_token=self.decoded_token,
                             sentry_dsn=self.sentry_dsn
                         )

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -1714,24 +1714,18 @@ def test_arg_file(dispatcher_live_fixture, dispatcher_test_conf, public_download
     file_hash = make_hash_file(p_file_path)
     dpars = urlencode(dict(file_list=file_hash,
                            _is_mmoda_url=True,
-                           return_archive=False,
-                           token=encoded_token))
+                           return_archive=False))
     local_download_url = f"{os.path.join(products_host_port, 'download_file')}?{dpars}"
 
     assert arg_download_url == local_download_url
 
     if public_download_request:
-        url_parts = urlparse(arg_download_url)
-        url_args = parse_qs(url_parts.query)
-        del url_args['token']
-        new_url_parts = url_parts._replace(query=urlencode(url_args, doseq=True))
-        arg_download_url = urlunparse(new_url_parts)
         c = requests.get(arg_download_url)
         assert c.status_code == 403
         jdata = c.json()
         assert jdata['exit_status']['message'] == "User cannot access the file"
     else:
-        # arg_download_url += f'&token={encoded_token}'
+        arg_download_url += f'&token={encoded_token}'
         c = requests.get(arg_download_url)
         assert c.status_code == 200
         with open(p_file_path) as p_file:
@@ -1793,8 +1787,7 @@ def test_arg_file_external_product_url(dispatcher_live_fixture_with_external_pro
     file_hash = make_hash_file(p_file_path)
     dpars = urlencode(dict(file_list=file_hash,
                            _is_mmoda_url=True,
-                           return_archive=False,
-                           token=encoded_token))
+                           return_archive=False))
     local_download_url = f"{os.path.join(dispatcher_test_conf_with_external_products_url['products_url'], 'dispatch-data/download_file')}?{dpars}"
 
     assert jdata['products']['analysis_parameters']['dummy_file'] == local_download_url
@@ -1854,8 +1847,7 @@ def test_arg_file_default_product_url(dispatcher_live_fixture_with_default_route
     file_hash = make_hash_file(p_file_path)
     dpars = urlencode(dict(file_list=file_hash,
                            _is_mmoda_url=True,
-                           return_archive=False,
-                           token=encoded_token))
+                           return_archive=False))
     local_download_url = f"{os.path.join(dispatcher_test_conf_with_default_route_products_url['products_url'], 'dispatch-data/download_file')}?{dpars}"
 
     assert jdata['products']['analysis_parameters']['dummy_file'] == local_download_url


### PR DESCRIPTION
Re-opening #718 .

After having discussed with @dsavchenko , the reason why the token was not added in the download url in the dispatcher was because this would impact the job_id calculation.

Reason why, it is handled at a nb2workflow level.