### PR TITLE
Open gallery endpoints

### DIFF
--- a/cdci_data_analysis/analysis/drupal_helper.py
+++ b/cdci_data_analysis/analysis/drupal_helper.py
@@ -901,7 +901,6 @@ def get_data_product_list_by_source_name_with_conditions(product_gallery_url, ga
         field_name = str.lower('field_' + k)
         params[field_name] = v
 
-    # if source_entity_id is not None:
     log_res = execute_drupal_request(request_url,
                                      params=params,
                                      headers=headers,

--- a/cdci_data_analysis/analysis/drupal_helper.py
+++ b/cdci_data_analysis/analysis/drupal_helper.py
@@ -920,39 +920,6 @@ def get_data_product_list_by_source_name_with_conditions(product_gallery_url, ga
     return product_list
 
 
-def get_data_product_list_by_source_name(product_gallery_url, gallery_jwt_token, src_name=None, sentry_dsn=None) -> Optional[list]:
-    product_list = []
-    if src_name is None:
-        return  product_list
-    headers = get_drupal_request_headers(gallery_jwt_token)
-
-    source_entity_list = get_source_astrophysical_entity_info_by_source_and_alternative_name(product_gallery_url,
-                                                                                         gallery_jwt_token,
-                                                                                         source_name=src_name,
-                                                                                         sentry_dsn=sentry_dsn)
-
-    source_entity_id = None
-    if len(source_entity_list) >= 1:
-        source_entity_id = source_entity_list[0]['nid']
-
-    if source_entity_id is not None:
-        log_res = execute_drupal_request(f"{product_gallery_url}/data_products/source_products/{source_entity_id}",
-                                         headers=headers,
-                                         sentry_dsn=sentry_dsn)
-        output_get = analyze_drupal_output(log_res, operation_performed="retrieving the astrophysical entity information")
-        if isinstance(output_get, list):
-            for obj in output_get:
-                refactored_obj = {}
-                for k, v in obj.items():
-                    refactored_key = k
-                    if k.startswith('field_'):
-                        refactored_key = k.replace('field_', '')
-                    refactored_obj[refactored_key] = v
-                product_list.append(refactored_obj)
-
-    return product_list
-
-
 def get_all_source_astrophysical_entities(product_gallery_url, gallery_jwt_token, sentry_dsn=None) -> Optional[list]:
     entities = []
     headers = get_drupal_request_headers(gallery_jwt_token)

--- a/cdci_data_analysis/analysis/drupal_helper.py
+++ b/cdci_data_analysis/analysis/drupal_helper.py
@@ -885,23 +885,12 @@ def get_all_revolutions(product_gallery_url, gallery_jwt_token, sentry_dsn=None)
     return entities
 
 
-def get_data_product_list_by_source_name_with_conditions(product_gallery_url, gallery_jwt_token,
+def get_data_product_list_by_source_name_with_conditions(product_gallery_url, gallery_jwt_token=None,
                                                          sentry_dsn=None,
                                                          **kwargs
                                                          ) -> Optional[list]:
     headers = get_drupal_request_headers(gallery_jwt_token)
     product_list = []
-    # if src_name is None:
-    #     source_entity_id = "all"
-    # else:
-    #     source_entity_list = get_source_astrophysical_entity_info_by_source_and_alternative_name(product_gallery_url,
-    #                                                                                          gallery_jwt_token,
-    #                                                                                          source_name=src_name,
-    #                                                                                          sentry_dsn=sentry_dsn)
-
-        # source_entity_id = None
-        # if len(source_entity_list) >= 1:
-        #     source_entity_id = source_entity_list[0]['nid']
 
     request_url = f"{product_gallery_url}/data_products/source_products_conditions"
 

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -953,7 +953,6 @@ def get_data_product_list_with_conditions():
     return output_list
 
 
-# TODO to refactor using get_data_product_list_with_conditions
 @app.route('/get_data_product_list_by_source_name', methods=['GET'])
 def get_data_product_list_by_source_name():
     par_dic = request.values.to_dict()
@@ -985,12 +984,11 @@ def get_data_product_list_by_source_name():
     # update the token
     gallery_jwt_token = drupal_helper.generate_gallery_jwt_token(gallery_secret_key, user_id=user_id_product_creator)
 
-    src_name = request.args.get('src_name', None)
+    output_get = drupal_helper.get_data_product_list_by_source_name_with_conditions(product_gallery_url=product_gallery_url,
+                                                                                    gallery_jwt_token=gallery_jwt_token,
+                                                                                    sentry_dsn=sentry_dsn,
+                                                                                    **par_dic)
 
-    output_get = drupal_helper.get_data_product_list_by_source_name(product_gallery_url=product_gallery_url,
-                                                                    gallery_jwt_token=gallery_jwt_token,
-                                                                    src_name=src_name,
-                                                                    sentry_dsn=sentry_dsn)
     output_list = json.dumps(output_get)
 
     return output_list

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -953,27 +953,29 @@ def get_data_product_list_by_source_name():
 
     token = par_dic.pop('token', None)
     app_config = app.config.get('conf')
-    secret_key = app_config.secret_key
-
-    output, output_code = tokenHelper.validate_token_from_request(token=token, secret_key=secret_key,
-                                                                  required_roles=['gallery contributor'],
-                                                                  action="getting all the astro entities from the product gallery")
-
-    if output_code is not None:
-        return make_response(output, output_code)
-    decoded_token = output
-
-
     sentry_dsn = sentry.sentry_url
 
-    gallery_secret_key = app_config.product_gallery_secret_key
+    secret_key = app_config.secret_key
     product_gallery_url = app_config.product_gallery_url
-    user_email = tokenHelper.get_token_user_email_address(decoded_token)
-    user_id_product_creator = drupal_helper.get_user_id(product_gallery_url=product_gallery_url,
-                                                        user_email=user_email,
-                                                        sentry_dsn=sentry_dsn)
-    # update the token
-    gallery_jwt_token = drupal_helper.generate_gallery_jwt_token(gallery_secret_key, user_id=user_id_product_creator)
+    gallery_secret_key = app_config.product_gallery_secret_key
+    gallery_jwt_token = None
+
+    if token is not None:
+
+        output, output_code = tokenHelper.validate_token_from_request(token=token, secret_key=secret_key,
+                                                                      required_roles=['gallery contributor'],
+                                                                      action="getting all the astro entities from the product gallery")
+
+        if output_code is not None:
+            return make_response(output, output_code)
+        decoded_token = output
+
+        user_email = tokenHelper.get_token_user_email_address(decoded_token)
+        user_id_product_creator = drupal_helper.get_user_id(product_gallery_url=product_gallery_url,
+                                                            user_email=user_email,
+                                                            sentry_dsn=sentry_dsn)
+        # update the token
+        gallery_jwt_token = drupal_helper.generate_gallery_jwt_token(gallery_secret_key, user_id=user_id_product_creator)
 
     output_get = drupal_helper.get_data_product_list_by_source_name_with_conditions(product_gallery_url=product_gallery_url,
                                                                                     gallery_jwt_token=gallery_jwt_token,

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -922,26 +922,27 @@ def get_data_product_list_with_conditions():
 
     token = par_dic.pop('token', None)
     app_config = app.config.get('conf')
-    secret_key = app_config.secret_key
-
-    output, output_code = tokenHelper.validate_token_from_request(token=token, secret_key=secret_key,
-                                                                  required_roles=['gallery contributor'],
-                                                                  action="getting all the astro entities from the product gallery")
-
-    if output_code is not None:
-        return make_response(output, output_code)
-    decoded_token = output
-
     sentry_dsn = sentry.sentry_url
 
+    secret_key = app_config.secret_key
     gallery_secret_key = app_config.product_gallery_secret_key
     product_gallery_url = app_config.product_gallery_url
-    user_email = tokenHelper.get_token_user_email_address(decoded_token)
-    user_id_product_creator = drupal_helper.get_user_id(product_gallery_url=product_gallery_url,
-                                                        user_email=user_email,
-                                                        sentry_dsn=sentry_dsn)
-    # update the token
-    gallery_jwt_token = drupal_helper.generate_gallery_jwt_token(gallery_secret_key, user_id=user_id_product_creator)
+    gallery_jwt_token = None
+
+    if token is not None:
+        output, output_code = tokenHelper.validate_token_from_request(token=token, secret_key=secret_key,
+                                                                      action="getting all the astro entities from the product gallery")
+
+        if output_code is not None:
+            return make_response(output, output_code)
+        decoded_token = output
+
+
+        user_email = tokenHelper.get_token_user_email_address(decoded_token)
+        user_id_product_creator = drupal_helper.get_user_id(product_gallery_url=product_gallery_url,
+                                                            user_email=user_email,
+                                                            sentry_dsn=sentry_dsn)
+        gallery_jwt_token = drupal_helper.generate_gallery_jwt_token(gallery_secret_key, user_id=user_id_product_creator)
 
     output_get = drupal_helper.get_data_product_list_by_source_name_with_conditions(product_gallery_url=product_gallery_url,
                                                                                     gallery_jwt_token=gallery_jwt_token,

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -637,16 +637,7 @@ def resolve_name():
     sanitized_par_dic = sanitize_dict_before_log(par_dic)
     logger.info("request.args: %s ", sanitized_par_dic)
 
-    token = par_dic.pop('token', None)
     app_config = app.config.get('conf')
-    secret_key = app_config.secret_key
-
-    output, output_code = tokenHelper.validate_token_from_request(token=token, secret_key=secret_key,
-                                                                  required_roles=['gallery contributor'],
-                                                                  action="post on the product gallery")
-
-    if output_code is not None:
-        return make_response(output, output_code)
 
     name = par_dic.get('name', None)
 

--- a/cdci_data_analysis/flask_app/app.py
+++ b/cdci_data_analysis/flask_app/app.py
@@ -912,7 +912,7 @@ def get_astro_entity_info_by_source_name():
 
     return refactored_astro_entity_info
 
-
+# TODO in the gallery, in case of token is passed, it'll be checked against the 'integral-private-qla' role, to get also the private data
 @app.route('/get_data_product_list_with_conditions', methods=['GET'])
 def get_data_product_list_with_conditions():
     par_dic = request.values.to_dict()

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -3241,7 +3241,8 @@ def test_product_gallery_get_all_astro_entities(dispatcher_live_fixture_with_gal
 @pytest.mark.test_drupal
 @pytest.mark.parametrize("source_name", ["new", "known", "unknown"])
 @pytest.mark.parametrize("include_products_fields_conditions", [True, False])
-def test_product_gallery_get_data_products_list_with_conditions(dispatcher_live_fixture_with_gallery, dispatcher_test_conf_with_gallery, source_name, include_products_fields_conditions):
+@pytest.mark.parametrize("request_type", ["private", "public"])
+def test_product_gallery_get_data_products_list_with_conditions(dispatcher_live_fixture_with_gallery, dispatcher_test_conf_with_gallery, source_name, include_products_fields_conditions, request_type):
     server = dispatcher_live_fixture_with_gallery
 
     logger.info("constructed server: %s", server)
@@ -3296,6 +3297,10 @@ def test_product_gallery_get_data_products_list_with_conditions(dispatcher_live_
             'instrument_name': instrument_query,
             'product_type': product_type_query
         }
+
+        if request_type == "public":
+            params.pop('token')
+
         if include_products_fields_conditions:
             for e1_kev, e2_kev, rev1, rev2 in [
                 (100, 350, 2528, 2540),

--- a/tests/test_server_basic.py
+++ b/tests/test_server_basic.py
@@ -2698,7 +2698,8 @@ def test_get_query_products_exception(dispatcher_live_fixture):
 
 @pytest.mark.test_drupal
 @pytest.mark.parametrize("source_to_resolve", ['Mrk 421', 'Mrk_421', 'GX 1+4', 'fake object', None])
-def test_source_resolver(dispatcher_live_fixture_with_gallery, dispatcher_test_conf_with_gallery, source_to_resolve):
+@pytest.mark.parametrize("request_type", ["private", "public"])
+def test_source_resolver(dispatcher_live_fixture_with_gallery, dispatcher_test_conf_with_gallery, source_to_resolve, request_type):
     server = dispatcher_live_fixture_with_gallery
 
     logger.info("constructed server: %s", server)
@@ -2712,6 +2713,9 @@ def test_source_resolver(dispatcher_live_fixture_with_gallery, dispatcher_test_c
 
     params = {'name': source_to_resolve,
               'token': encoded_token}
+
+    if request_type == "private":
+        params.pop('token', None)
 
     c = requests.get(os.path.join(server, "resolve_name"),
                      params={**params}


### PR DESCRIPTION
Following the request from @francoismg  and @ferrigno , the following endpoints no longer require the token:

* `resolve_name`
* `get_data_product_list_with_conditions` (it will be optional as a further check will be implemented in the gallery)
* `get_data_product_list_by_source_name` (along with a small refactoring: it uses now, the more general drupal endpoint to get a list of `data_product`s given a certain set of conditions)