### PR TITLE
`os.scandir` instead of `glob` in `get_existing_job_ID_path`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "sentry-sdk",
     "validators==0.28.3",
     "jsonschema<=4.17.3",
-    'psycopg2-binary'
+    'psycopg2'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Optimises execution time of the method if scratch dir contains lots of entries. 

Mitigation for https://github.com/oda-hub/dispatcher-app/issues/767